### PR TITLE
Add UnsetAll to EnvironmentVariables

### DIFF
--- a/platform/environment_variables.go
+++ b/platform/environment_variables.go
@@ -17,9 +17,11 @@
 package platform
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/buildpack/libbuildpack/logger"
 )
@@ -36,6 +38,28 @@ func (e EnvironmentVariables) SetAll() error {
 	}
 
 	return nil
+}
+
+// UnsetAll unsets all of the environment variable content in the current process environment.
+func (e EnvironmentVariables) UnsetAll() error {
+	for key := range e {
+		if err := os.Unsetenv(key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// String makes EnvironmentVariables satisfy the Stringer interface.
+func (e EnvironmentVariables) String() string {
+	var entries []string
+
+	for k, v := range e {
+		entries = append(entries, fmt.Sprintf("%s: %s", k, v))
+	}
+
+	return fmt.Sprintf("EnvironmentVariables{ %s }", strings.Join(entries, ", "))
 }
 
 func environmentVariables(root string, logger logger.Logger) (EnvironmentVariables, error) {

--- a/platform/environment_variables.go
+++ b/platform/environment_variables.go
@@ -17,11 +17,9 @@
 package platform
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/buildpack/libbuildpack/logger"
 )
@@ -49,17 +47,6 @@ func (e EnvironmentVariables) UnsetAll() error {
 	}
 
 	return nil
-}
-
-// String makes EnvironmentVariables satisfy the Stringer interface.
-func (e EnvironmentVariables) String() string {
-	var entries []string
-
-	for k, v := range e {
-		entries = append(entries, fmt.Sprintf("%s: %s", k, v))
-	}
-
-	return fmt.Sprintf("EnvironmentVariables{ %s }", strings.Join(entries, ", "))
 }
 
 func environmentVariables(root string, logger logger.Logger) (EnvironmentVariables, error) {

--- a/platform/environment_variables_test.go
+++ b/platform/environment_variables_test.go
@@ -49,5 +49,23 @@ func TestEnvironmentVariables(t *testing.T) {
 			g.Expect(os.Getenv("TEST_KEY_2")).To(Equal("test-value-2"))
 		})
 
+		it("unsets all platform environment variables", func(){
+			root := internal.ScratchDir(t, "platform")
+			defer internal.ProtectEnv(t, "TEST_KEY_1", "TEST_KEY_2")()
+
+			internal.WriteTestFile(t, filepath.Join(root, "env", "TEST_KEY_1"), "test-value-1")
+			internal.WriteTestFile(t, filepath.Join(root, "env", "TEST_KEY_2"), "test-value-2")
+
+			platform, err := platform.DefaultPlatform(root, logger.Logger{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(platform.EnvironmentVariables.SetAll()).To(Succeed())
+			g.Expect(platform.EnvironmentVariables.UnsetAll()).To(Succeed())
+			_, testKey1IsPresent := os.LookupEnv("TEST_KEY_1")
+			_, testKey2IsPresent := os.LookupEnv("TEST_KEY_2")
+			g.Expect(testKey1IsPresent).To(BeFalse())
+			g.Expect(testKey2IsPresent).To(BeFalse())
+		})
+
 	}, spec.Report(report.Terminal{}))
 }


### PR DESCRIPTION
This PR adds an `UnsetAll` method to `EnvironmentVariables`.

### Use Case
When using libbuildpack we were able to set the environment variables easily, but it was not as easy to unset them afterwards (e.g. when cleaning up after testing).  This commit provides a method to unset variables as easily as setting them.

Unit test is provided.